### PR TITLE
fixed get-pip fallback download for proxy + md5 check

### DIFF
--- a/toolbar/mlops.shelf
+++ b/toolbar/mlops.shelf
@@ -16,6 +16,8 @@
 import subprocess
 import os
 import hashlib
+from urllib import request
+import ssl
 
 FOLDER = os.path.normpath(os.path.join(hou.text.expandString("$HOUDINI_TEMP_DIR"), "MLOPs"))
 PIP_FOLDER = os.path.normpath(os.path.join(hou.text.expandString("$HOUDINI_USER_PREF_DIR"), "scripts", "python"))
@@ -32,31 +34,44 @@ with hou.InterruptableOperation("Installing Dependencies, downloading ~5Gb", ope
     flags = 0
     if os.name == 'nt':
         flags = subprocess.CREATE_NO_WINDOW
-    # Trying to download get-pip with SSL
+    # Trying to download get-pip with curl , this can quietly fail when behind proxy 
+    hou.ui.setStatusMessage("curl download get-pip.py")
     p = subprocess.Popen(["curl", "-o", PIPINSTALLFILE, "https://bootstrap.pypa.io/get-pip.py"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, creationflags = flags)
     out, err = p.communicate()
     if err:
         raise hou.Error(out.decode())
-    operation.updateProgress(percentage=count/total)
-    count+=1
 
-    # Checking if get-pip downloaded , otherwise try no SSL with safe MD5 check  
+    # Checking if get-pip downloaded with curl , otherwise try download previous get-pip using urllib with SSL certification and test Md5 hash for safety
     if not os.path.isfile(PIPINSTALLFILE):
-        p = subprocess.Popen(["curl", "-o", PIPINSTALLFILE, "https://bootstrap.pypa.io/get-pip.py", "--ssl-no-revoke"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, creationflags = flags)
-        out, err = p.communicate()
-        if err:
-          raise hou.Error(out.decode())
-        safe_md5 = '6f33e0cffbbd2093f2406f8d0839b01f'  
+      hou.ui.setStatusMessage("curl failed to download get-pip.py , trying urllib.")
+      remote_url = "https://github.com/pypa/get-pip/raw/2b873b978dbfdfc5e15ef5c3adf4354084612432/public/get-pip.py" # last known get-pip.py from 20230422
+      # Create an SSL context with certificate verification
+      context = ssl.create_default_context()
+      context.check_hostname = True
+      context.verify_mode = ssl.CERT_REQUIRED
+      with request.urlopen(remote_url, context=context) as response:
+          with open(PIPINSTALLFILE, 'wb') as file:
+              while True:
+                  chunk = response.read(1024)
+                  if not chunk:
+                      break
+                  file.write(chunk)
+      if os.path.isfile(PIPINSTALLFILE):
+        hou.ui.setStatusMessage("testing get-pip.py MD5.")
+        safe_md5 = '6f33e0cffbbd2093f2406f8d0839b01f'  # last known get-pip.py MD5 hash from 20230422
         test_md5 = hashlib.md5(open(PIPINSTALLFILE,'rb').read()).hexdigest()
-        if safe_md5 != test_md5:
-          os.remove(PIPINSTALLFILE)
+        if safe_md5 != test_md5: 
+          os.remove(PIPINSTALLFILE) # delete the unsafe get-pip.py if doesnt match 
           raise hou.Error("unsafe get-pip.py downloaded with incorrect MD5hash. safe_MD5 = " + safe_md5 + " != " + test_md5)
+
+    # If that also fails to download , then error out and ask for manual download
     if not os.path.isfile(PIPINSTALLFILE):
-      raise hou.Error("get-pip.py not found in = " + PIPINSTALLFILE)
+      raise hou.Error("Failed to download get-pip.py , please download get-pip.py manually from https://bootstrap.pypa.io/ , and place in here = " + PIPINSTALLFILE  )
     operation.updateProgress(percentage=count/total)
     count+=1
 
     # Installing pip to Houdini
+    hou.ui.setStatusMessage("Installing pip to Houdini")
     p = subprocess.Popen(["hython", PIPINSTALLFILE], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, creationflags = flags)
     out, err = p.communicate()
     if err:
@@ -66,6 +81,7 @@ with hou.InterruptableOperation("Installing Dependencies, downloading ~5Gb", ope
 
 
     # Installing / Upgrading setuptools because on py3.9 some modules need to be rebuilt
+    hou.ui.setStatusMessage("Installing / Upgrading setuptools ")
     p = subprocess.Popen(["hython", "-m", "pip", "install", "--upgrade", PIP_FOLDER, "setuptools"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, creationflags = flags)
     out, err = p.communicate()
     if err:
@@ -73,13 +89,15 @@ with hou.InterruptableOperation("Installing Dependencies, downloading ~5Gb", ope
     operation.updateProgress(percentage=count/total)
     count+=1
         
+    hou.ui.setStatusMessage("Installing torch ")
     p = subprocess.Popen(["hython", "-m", "pip", "install", "--target", PIP_FOLDER, "torch", "--index-url", "https://download.pytorch.org/whl/cu117"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, creationflags = flags)
     out, err = p.communicate()
     if err:
         raise hou.Error(out.decode())
     operation.updateProgress(percentage=count/total)
     count+=1
-        
+
+    hou.ui.setStatusMessage("Installing openai, omegaconf, transformers, accelerate, scipy, opencv-contrib-python, controlnet_aux, torchmetrics, clip_interrogator")    
     p = subprocess.Popen(["hython", "-m", "pip", "install", "--target", PIP_FOLDER, "openai", "omegaconf", "transformers", "accelerate", "scipy", "opencv-contrib-python", "controlnet_aux", "torchmetrics", "clip_interrogator"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,creationflags = flags)
     out, err = p.communicate()
     if err:
@@ -87,6 +105,7 @@ with hou.InterruptableOperation("Installing Dependencies, downloading ~5Gb", ope
     operation.updateProgress(percentage=count/total)
     count+=1
 
+    hou.ui.setStatusMessage("Installing diffusers 0.15.0 ")
     p = subprocess.Popen(["hython", "-m", "pip", "install", "--target", PIP_FOLDER, "diffusers==0.15.0"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,creationflags = flags)
     out, err = p.communicate()
     if err:


### PR DESCRIPTION
Installing Dependencies when behind proxy sometimes causes the curl download of get-pip.py to fail , as a secondary fallback this tries to then use urllib to download a specific previous version from pypa's github that we can then verify by md5 hash . this fixes the issue of needing to update the md5 check for each update of get-pip.py  as this fallback is now getting a specific version with verified md5 hash . also added status messages .