### PR TITLE
Light changes to schedulers/Samplers

### DIFF
--- a/scripts/python/sdpipeline/image_solve.py
+++ b/scripts/python/sdpipeline/image_solve.py
@@ -146,6 +146,8 @@ def run(inference_steps, latent_dimension, input_embeddings, controlnet_geo, att
     # if True:
         for i, t in enumerate(tqdm(timesteps, disable=True)):
             latent_model_input = torch.cat([latents] * 2)
+            #converting timestep to cpu for compatibility with all samplers
+            t = t.to('cpu')
             latent_model_input = scheduler.scale_model_input(latent_model_input, timestep=t).to(dtype_unet)
 
             if controlnet_geo:

--- a/scripts/python/sdpipeline/scheduler.py
+++ b/scripts/python/sdpipeline/scheduler.py
@@ -46,5 +46,8 @@ def run(input_latents, latent_dimension, image_latents, guiding_strength, infere
     config = scheduler_object.config
     config["init_timesteps"] = t_start
     config["type"] = scheduler_model
+    # A bit of a lame way to add Karras sigmas : just check if the menu label contains "Karras". bandaid.
+    if 'karras' in str(scheduler_model).lower():
+        config["use_karras_sigmas"] = True
     scheduler["config"] = config
     return scheduler

--- a/scripts/python/sdpipeline/schedulers_lookup.py
+++ b/scripts/python/sdpipeline/schedulers_lookup.py
@@ -1,22 +1,26 @@
-from diffusers import DDIMScheduler,DDPMScheduler,DEISMultistepScheduler,DPMSolverMultistepScheduler,DPMSolverSinglestepScheduler,EulerAncestralDiscreteScheduler,EulerDiscreteScheduler,PNDMScheduler,UniPCMultistepScheduler,LMSDiscreteScheduler
+from diffusers import HeunDiscreteScheduler,KDPM2DiscreteScheduler,KDPM2AncestralDiscreteScheduler,DDIMScheduler,DDPMScheduler,DEISMultistepScheduler,DPMSolverMultistepScheduler,DPMSolverSinglestepScheduler,EulerAncestralDiscreteScheduler,EulerDiscreteScheduler,UniPCMultistepScheduler,LMSDiscreteScheduler
 
 schedulers = {
 	"unipc" : UniPCMultistepScheduler,
-	"euler_discrete" : EulerDiscreteScheduler,
-	"euler_ancestral" : EulerAncestralDiscreteScheduler,
-	"lms_discrete" : LMSDiscreteScheduler,
+	"euler" : EulerDiscreteScheduler,
+	"euler a" : EulerAncestralDiscreteScheduler,
+	"LMS" : LMSDiscreteScheduler,
+	"Heun" : HeunDiscreteScheduler,
+	"Heun Karras" : HeunDiscreteScheduler,
 	"ddim" : DDIMScheduler,
 	#"DDIMInverse" : DDIMInverseScheduler,
 	"DDPM" : DDPMScheduler,
 	"DEIS_Multistep" : DEISMultistepScheduler,
-	"DPM_Multistep" : DPMSolverMultistepScheduler,
-	"DPM_Singlestep" : DPMSolverSinglestepScheduler,
-	#"HeunDiscrete" : HeunDiscreteScheduler,
+	"DPM2 Karras" : KDPM2DiscreteScheduler,
+	"DPM2 a Karras" : KDPM2AncestralDiscreteScheduler,
+	"DPM++ 2S" : DPMSolverSinglestepScheduler,
+	# No argument to "turn" the following into Karras version yet
+	# "DPM++ 2S Karras" : DPMSolverSinglestepScheduler(use_karras_sigmas=True),
+	"DPM++ 2M" : DPMSolverMultistepScheduler,
+	"DPM++ 2M Karras" : DPMSolverMultistepScheduler,
 	#"IPNDM" : IPNDMScheduler,
-	#"KDPM2Ancestral" : KDPM2AncestralDiscreteScheduler,
-	#"KDPM2" : KDPM2DiscreteScheduler,
 	#"KarrasVe" : KarrasVeScheduler,
-	"PNDM" : PNDMScheduler,
+	#"PNDM" : PNDMScheduler,
 	#"RePaint" : RePaintScheduler,
 	#"UnCLIP" : UnCLIPScheduler,
 	#"VQDiffusion" : VQDiffusionScheduler


### PR DESCRIPTION
- In image_solve.py, ensured compatibility with all samplers by converting timestep to CPU
- Reworked schedulers_lookup.py to bring out more common names ( in relation to webuis out there )
- Apply Karras sigmas based on menu label for now