### PR TITLE
Allow PIP Folder location to be externally defined.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@ checkpoints/*/
 data/temp/
 data/models/
 data/dependencies/
+data/versions/
 
 #ignore other unimportant expanded HDA files
 *.OPfallbacks
 *.OPdummydefs
 *.createtimes
 *.modtimes
+*.local

--- a/MLOPs.json
+++ b/MLOPs.json
@@ -11,7 +11,10 @@
             "MLOPS_MODELS": "$MLOPS/data/models/"
         },
         {
-            "MLOPS_SD_MODEL": "$MLOPS/data/models/diffusers/runwayml-_-stable-diffusion-v1-5"
+            "MLOPS_PIP_FOLDER": "$MLOPS/data/dependencies/python/"
+        },
+        {
+            "MLOPS_SD_MODEL": "$MLOPS_MODELS/diffusers/runwayml-_-stable-diffusion-v1-5"
         },
         {
             "OPENAI_API_KEY": "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"
@@ -23,7 +26,7 @@
             "PYTHONPATH" : 
             {
 
-                "value": ["$MLOPS/data/dependencies/python/", "$MLOPS/scripts/python/characterpipeline/AlphaPose",
+                "value": ["$MLOPS_PIP_FOLDER", "$MLOPS/scripts/python/characterpipeline/AlphaPose",
                 "$MLOPS/scripts/python/characterpipeline/MotionBert"],
                 "method": "prepend"
             }

--- a/scripts/python/mlops_utils.py
+++ b/scripts/python/mlops_utils.py
@@ -10,9 +10,7 @@ import mlops_image_utils
 import hou
 from hutil.Qt import QtCore, QtGui, QtWidgets
 
-PIP_FOLDER = os.path.normpath(
-    os.path.join(hou.text.expandString("$MLOPS"), "data", "dependencies", "python")
-)
+PIP_FOLDER = hou.text.expandString("$MLOPS_PIP_FOLDER")
 
 
 def install_mlops_dependencies():


### PR DESCRIPTION
This PR introduces a single change allowing the folder where models are stored to be defined externally. It is backward compatible with the current setup, but allows more advanced users and maintainers to easily switch between MLOPs versions