### PR TITLE
Fix "Install Dependencies" shelf tool

### DIFF
--- a/scripts/python/mlops_utils.py
+++ b/scripts/python/mlops_utils.py
@@ -278,8 +278,8 @@ def check_mlops_version():
     installed_json = None
     for package in packages:
         package = packages[package]
-        if "Environment variables" in package.keys():
-            vars = package["Environment variables"]
+        if "Environment Variables" in package.keys():
+            vars = package["Environment Variables"]
             if "MLOPS" in vars.keys():
                 installed_json = os.path.normpath(package["File path"])
                 variables = vars.keys()

--- a/scripts/python/mlops_utils.py
+++ b/scripts/python/mlops_utils.py
@@ -285,7 +285,8 @@ def check_mlops_version():
                 variables = vars.keys()
                 break
     variables = list(variables)
-    variables.remove("HOUDINI_PATH")
+    if "HOUDINI_PATH" in variables:
+        variables.remove("HOUDINI_PATH")
 
     plugin_json = os.path.normpath(hou.text.expandString("$MLOPS/MLOPs.json"))
     with open(plugin_json, "r", encoding="utf-8") as infile:


### PR DESCRIPTION
Using the "Install Dependencies"  shelf tool fails with the error:

Traceback (most recent call last):
  File "mlops_install", line 5, in <module>
  File "C:\work/MLOPs/scripts/python\mlops_utils.py", line 22, in install_mlops_dependencies
    check_mlops_version()
  File "C:\work/MLOPs/scripts/python\mlops_utils.py", line 288, in check_mlops_version
    variables.remove("HOUDINI_PATH")
ValueError: list.remove(x): x not in list

This change updates the value searched in the package's keys. You can verify there is no values with "Environment variables" (lowercase v) present with the following script tested in houdini 20.5.410 python shell.

```
import json
packages = json.loads(hou.ui.packageInfo())
[print(item.keys()) for item in json.loads(hou.ui.packageInfo()).values()]

>>> [print(item.keys()) for item in json.loads(hou.ui.packageInfo()).values()]
dict_keys(['Version', 'Show', 'Locked', 'Auto load', 'Active', 'File path', 'load_package_once', 'enable', 'Environment Variables', 'Resources'])
dict_keys(['Show', 'Locked', 'Auto load', 'Active', 'File path', 'Environment Variables', 'Resources'])
dict_keys(['Show', 'Locked', 'Auto load', 'Active', 'File path', 'Environment Variables'])
dict_keys(['Show', 'Locked', 'Auto load', 'Active', 'File path', 'Environment Variables', 'Resources'])
dict_keys(['Show', 'Locked', 'Auto load', 'Active', 'File path', 'Environment Variables'])
dict_keys(['Show', 'Locked', 'Auto load', 'Active', 'File path', 'package_path', 'Environment Variables'])
dict_keys(['Show', 'Locked', 'Auto load', 'Active', 'File path', 'Environment Variables', 'Resources'])
dict_keys(['Version', 'Show', 'Locked', 'Auto load', 'Active', 'File path', 'load_package_once', 'enable', 'Environment Variables', 'Resources'])
[None, None, None, None, None, None, None, None]
```

Note this will lead to another error not handled by this PR referenced here #158 